### PR TITLE
Fix ESLint import order error

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+
 export function containsKanji(text) {
   return /[一-龯]/.test(text);
 }
@@ -8,7 +10,6 @@ export function convertKatakanaToHiragana(text) {
   );
 }
 
-import React, { useState } from 'react';
 
 export function BlurredText({ children }) {
   const [blurred, setBlurred] = useState(true);


### PR DESCRIPTION
## Summary
- move React import to the top of `helpers.js`

## Testing
- `npx react-app-rewired test --watchAll=false` *(fails: 403 Forbidden to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68470cbaa70c8325963aa99bf066556a