### PR TITLE
Add local caching for API results

### DIFF
--- a/src/AdjectiveConjugator.js
+++ b/src/AdjectiveConjugator.js
@@ -91,6 +91,14 @@ function AdjectiveConjugator() {
     setError("");
     setResult(null);
 
+    // Check localStorage cache first
+    const cache = JSON.parse(localStorage.getItem('adjectiveCache') || '{}');
+    if (cache[inputAdjective]) {
+      setResult(cache[inputAdjective]);
+      setLoading(false);
+      return;
+    }
+
     const prompt = `
 Please provide a Japanese adjective conjugation table for the adjective "${inputAdjective}".
 ${inputCategory ? `It belongs to the "${inputCategory}" category.` : ""}
@@ -181,6 +189,12 @@ Output a JSON object with the following structure (and no additional text):
         console.error("Failed to parse API response:", messageContent);
         throw new Error("Failed to parse API response as JSON.");
       }
+
+      // Cache the result in localStorage
+      const cache = JSON.parse(localStorage.getItem('adjectiveCache') || '{}');
+      cache[inputAdjective] = conjugationData;
+      localStorage.setItem('adjectiveCache', JSON.stringify(cache));
+
       setResult(conjugationData);
     } catch (err) {
       setError(err.message);

--- a/src/components/VerbConjugator.js
+++ b/src/components/VerbConjugator.js
@@ -85,6 +85,14 @@ export default function VerbConjugator() {
     setError('');
     setResult(null);
 
+    // Check localStorage cache first
+    const cache = JSON.parse(localStorage.getItem('verbCache') || '{}');
+    if (cache[inputVerb]) {
+      setResult(cache[inputVerb]);
+      setLoading(false);
+      return;
+    }
+
     const prompt = `
 Please provide a Japanese verb conjugation table for the verb "${inputVerb}".
 ${inputCategory ? `It belongs to the category "${inputCategory}".` : ''}
@@ -139,6 +147,12 @@ Output a JSON object with the following structure (and no additional text):
         console.error('Failed to parse API response:', messageContent);
         throw new Error('Failed to parse API response as JSON.');
       }
+
+      // Cache the result in localStorage
+      const cache = JSON.parse(localStorage.getItem('verbCache') || '{}');
+      cache[inputVerb] = conjugationData;
+      localStorage.setItem('verbCache', JSON.stringify(cache));
+
       setResult(conjugationData);
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
## Summary
- cache verb conjugations in `localStorage` to avoid duplicate API calls
- cache adjective conjugations in `localStorage`

## Testing
- `npm test --silent` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847187bba9083258c851935e22b6779