### PR TITLE
Fix blur reset when word changes

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export function containsKanji(text) {
   return /[一-龯]/.test(text);
@@ -13,6 +13,11 @@ export function convertKatakanaToHiragana(text) {
 
 export function BlurredText({ children }) {
   const [blurred, setBlurred] = useState(true);
+
+  useEffect(() => {
+    setBlurred(true);
+  }, [children]);
+
   return (
     <span className={blurred ? 'blurred' : ''} onClick={() => setBlurred(false)}>
       {children}


### PR DESCRIPTION
## Summary
- reset blurred text whenever its children change

## Testing
- `npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_684750e685948325a7968f2e3cc42f0b