### PR TITLE
Add Forvo search integration for conjugations

### DIFF
--- a/src/components/VerbConjugator.js
+++ b/src/components/VerbConjugator.js
@@ -189,9 +189,21 @@ export default function VerbConjugator() {
                 {result.conjugations.map((row, index) => (
                   <tr key={index}>
                     <td>{row.conjugation}</td>
-                    <td><BlurredText>{addFurigana(row.polite)}</BlurredText></td>
-                    <td><BlurredText>{addFurigana(row.plain)}</BlurredText></td>
-                    <td><BlurredText>{row.te ? addFurigana(row.te) : ''}</BlurredText></td>
+                    <td>
+                      <BlurredText searchTerm={row.polite}>
+                        {addFurigana(row.polite)}
+                      </BlurredText>
+                    </td>
+                    <td>
+                      <BlurredText searchTerm={row.plain}>
+                        {addFurigana(row.plain)}
+                      </BlurredText>
+                    </td>
+                    <td>
+                      <BlurredText searchTerm={row.te}>
+                        {row.te ? addFurigana(row.te) : ''}
+                      </BlurredText>
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -213,8 +225,16 @@ export default function VerbConjugator() {
                       <tr key={idx}>
                         <td>{ex.tense}</td>
                         <td>{ex.english}</td>
-                        <td><BlurredText>{addFurigana(ex.japanese_polite)}</BlurredText></td>
-                        <td><BlurredText>{addFurigana(ex.japanese_plain)}</BlurredText></td>
+                        <td>
+                          <BlurredText searchTerm={ex.japanese_polite}>
+                            {addFurigana(ex.japanese_polite)}
+                          </BlurredText>
+                        </td>
+                        <td>
+                          <BlurredText searchTerm={ex.japanese_plain}>
+                            {addFurigana(ex.japanese_plain)}
+                          </BlurredText>
+                        </td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -11,15 +11,23 @@ export function convertKatakanaToHiragana(text) {
 }
 
 
-export function BlurredText({ children }) {
+export function BlurredText({ children, searchTerm }) {
   const [blurred, setBlurred] = useState(true);
 
   useEffect(() => {
     setBlurred(true);
   }, [children]);
 
+  const handleClick = () => {
+    setBlurred(false);
+    if (searchTerm) {
+      const encoded = encodeURIComponent(searchTerm);
+      window.open(`https://forvo.com/search/${encoded}/`, '_blank');
+    }
+  };
+
   return (
-    <span className={blurred ? 'blurred' : ''} onClick={() => setBlurred(false)}>
+    <span className={blurred ? 'blurred' : ''} onClick={handleClick}>
       {children}
     </span>
   );


### PR DESCRIPTION
## Summary
- enable blurred text to open Forvo search results when clicked
- use new blurred text behaviour for conjugation table entries and examples

## Testing
- `npm test --silent --yes` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c13598e88325b844a3f23ade2e54