### PR TITLE
Adjust Forvo blurred text interaction

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -19,8 +19,9 @@ export function BlurredText({ children, searchTerm }) {
   }, [children]);
 
   const handleClick = () => {
-    setBlurred(false);
-    if (searchTerm) {
+    if (blurred) {
+      setBlurred(false);
+    } else if (searchTerm) {
       const encoded = encodeURIComponent(searchTerm);
       window.open(`https://forvo.com/search/${encoded}/`, '_blank');
     }


### PR DESCRIPTION
## Summary
- modify BlurredText so the first click just reveals text
- only open Forvo on the next click

## Testing
- `CI=true npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c6d913288325983f47c3c2fbc977