### PR TITLE
Adjust Forvo blurred text interaction

### DIFF
--- a/src/AdjectiveConjugator.js
+++ b/src/AdjectiveConjugator.js
@@ -193,10 +193,14 @@ function AdjectiveConjugator() {
                   <tr key={index}>
                     <td>{row.conjugation}</td>
                     <td>
-                      <BlurredText>{addFurigana(row.polite)}</BlurredText>
+                      <BlurredText searchTerm={row.polite}>
+                        {addFurigana(row.polite)}
+                      </BlurredText>
                     </td>
                     <td>
-                      <BlurredText>{addFurigana(row.plain)}</BlurredText>
+                      <BlurredText searchTerm={row.plain}>
+                        {addFurigana(row.plain)}
+                      </BlurredText>
                     </td>
                   </tr>
                 ))}
@@ -220,10 +224,14 @@ function AdjectiveConjugator() {
                         <td>{ex.tense}</td>
                         <td>{ex.english}</td>
                         <td>
-                          <BlurredText>{addFurigana(ex.japanese_polite)}</BlurredText>
+                          <BlurredText searchTerm={ex.japanese_polite}>
+                            {addFurigana(ex.japanese_polite)}
+                          </BlurredText>
                         </td>
                         <td>
-                          <BlurredText>{addFurigana(ex.japanese_plain)}</BlurredText>
+                          <BlurredText searchTerm={ex.japanese_plain}>
+                            {addFurigana(ex.japanese_plain)}
+                          </BlurredText>
                         </td>
                       </tr>
                     ))}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -19,8 +19,9 @@ export function BlurredText({ children, searchTerm }) {
   }, [children]);
 
   const handleClick = () => {
-    setBlurred(false);
-    if (searchTerm) {
+    if (blurred) {
+      setBlurred(false);
+    } else if (searchTerm) {
       const encoded = encodeURIComponent(searchTerm);
       window.open(`https://forvo.com/search/${encoded}/`, '_blank');
     }


### PR DESCRIPTION
## Summary
- modify BlurredText so the first click just reveals text
- only open Forvo on the next click
- enable Forvo search on adjective conjugations using `searchTerm`

## Testing
- `CI=true npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c6d913288325983f47c3c2fbc977