### PR TITLE
Add exact match flag to anime examples link

### DIFF
--- a/src/AdjectiveConjugator.js
+++ b/src/AdjectiveConjugator.js
@@ -245,7 +245,7 @@ function AdjectiveConjugator() {
                 href={`https://immersion-dictionary-r2saexnz6-mathew-chans-projects-22577ade.vercel.app/dictionary?keyword=${encodeURIComponent(
                   (result.conjugations.find(c => c.conjugation === 'Base Form')?.polite ||
                     result.title.replace(' Conjugation Table', ''))
-                )}&sort=sentence_length%3Aasc`}
+                )}&exact=true&sort=sentence_length%3Aasc`}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/components/VerbConjugator.js
+++ b/src/components/VerbConjugator.js
@@ -247,7 +247,7 @@ export default function VerbConjugator() {
                 href={`https://immersion-dictionary-r2saexnz6-mathew-chans-projects-22577ade.vercel.app/dictionary?keyword=${encodeURIComponent(
                   (result.conjugations.find(c => c.conjugation === 'Non-past Affirmative')?.polite ||
                     result.title.replace(' Conjugation Table', ''))
-                )}&sort=sentence_length%3Aasc`}
+                )}&exact=true&sort=sentence_length%3Aasc`}
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## Summary
- update anime link URLs to include `exact=true`

## Testing
- `npm test` *(fails: react-app-rewired not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5305ec9083259ee7b5321502332e